### PR TITLE
Edit to "create-index" in nodes.clj

### DIFF
--- a/src/clojure/clojurewerkz/neocons/rest/nodes.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/nodes.clj
@@ -165,7 +165,7 @@
                                      :query-string (if (:unique configuration)
                                                      {"unique" "true"}
                                                      {})
-                                     :body (json/json-str (merge {:name (name s)} (dissoc configuration :unique))))
+                                     :body (json/json-str (merge {:name (name s)} {:config (dissoc configuration :unique)})))
            payload (json/read-json body true)]
        (Index. (name s) (:template payload) (:provider configuration) (:type configuration)))))
 


### PR DESCRIPTION
This quick fix to the "create-index" function cleared up some problems I was having creating non-default (read: full-text) indexes. 

Before, all attempts to create a full-text index would just result in the default "type: exact" index. After looking in the code and reviewing Neo4j's REST docs, I think I've discovered the culprit. Just let me know if there's anything else I can do to help out here. Thanks for the great library! 
