### PR TITLE
Sensible defaults for instantiate-record-from

### DIFF
--- a/src/clojure/clojurewerkz/neocons/rest/records.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/records.clj
@@ -137,13 +137,16 @@
 
 
 (defn instantiate-record-from
-  "Instantiates a record from the given payload, detecting what kind of Neo4J entity (a node, a relationship,
-   a path) this payload represents"
+  "Instantiates a record from the given payload, detecting what kind
+  of Neo4J entity (a node, a relationship, a path) this payload
+  represents. Defaults to returning the object if we don't know how to
+  deal with it."
   [payload]
   (let [f (cond (:create_relationship payload)   instantiate-node-from
                 (and (:type payload)
                      (:data payload))            instantiate-rel-from
-                     (and (:start payload)
-                          (:end payload)
-                          (not (:type payload))) instantiate-path-from)]
+                (and (:start payload)
+                     (:end payload)
+                     (not (:type payload)))      instantiate-path-from
+                :else                            identity)]
     (f payload)))


### PR DESCRIPTION
When you hit a index looking for an item and that item doesn't exist for the given key-value pair, neocons throws errors. It tries to call instantiate-record-from on the payload returned from the index and is unable to because only a empty array is returned. Instead of throwing errors, this defaults to just passing back whatever it got from neo4j unchanged. Future work can be done for mapping over arrays of elements recursively, but right now I wanted to get something in that stops errors from getting thrown so  often on index misses. 
-Zack
