### PR TITLE
Add support for spatial plugin's basic REST interface functions.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,12 +9,14 @@
                  [clojurewerkz/support "0.7.0"]]
   :test-selectors {:default        (fn [m] (and (not (:time-consuming m))
                                                 (not (:http-auth m))
-                                                (not (:edge-features m))))
+                                                (not (:edge-features m))
+                                                (not (:spatial m))))
                    :time-consuming :time-consuming
                    :focus          :focus
                    :indexing       :indexing
                    :cypher         :cypher
                    :http-auth      :http-auth
+                   :spatial        :spatial
                    ;; as in, bleeding edge Neo4J Server
                    :edge-features  :edge-features
                    ;; assorted examples (extra integration tests)

--- a/src/clojure/clojurewerkz/neocons/rest/spatial.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/spatial.clj
@@ -1,0 +1,40 @@
+(ns clojurewerkz.neocons.rest.spatial
+  (:require [cheshire.custom           :as json]
+            [clojurewerkz.neocons.rest :as rest])
+  (:use     clojurewerkz.support.http.statuses
+            clojurewerkz.neocons.rest.helpers
+            clojurewerkz.neocons.rest.records)
+  (:import  [java.net URI URL]
+            clojurewerkz.neocons.rest.Neo4JEndpoint))
+
+;;
+;; Implementation
+;;
+
+(defn- spatial-location-for [^Neo4JEndpoint endpoint action]
+  (str (:uri endpoint) "ext/SpatialPlugin/graphdb/" action))
+
+(defn- post-spatial [item-type body]
+  (let [{:keys [status headers body]} (rest/POST
+                                        (spatial-location-for rest/*endpoint* item-type)
+                                        :body (json/encode body))
+        payload  (json/decode body true)]
+    (map instantiate-node-from payload)))
+
+;;
+;; API
+;;
+
+(defn add-simple-point-layer
+  "Add a new point layer to the spatial index"
+  ([layer lat lon] (first (post-spatial "addSimplePointLayer" {:layer layer :lat lat :lon lon})))
+  ([layer] (first (post-spatial "addSimplePointLayer" {:layer layer}))))
+  
+
+(defn add-node-to-layer [layer node]
+  "Add a node with the appropriate latitude and longitude properties to the given layer"
+  (first (post-spatial "addNodeToLayer" {:layer layer :node (node-location-for rest/*endpoint* (:id node))})))
+
+(defn find-within-distance [layer point-x point-y distance-in-km]
+  "Find all points in the layer within a given distance of the given point"
+  (post-spatial "findGeometriesWithinDistance" {:layer layer :pointX point-x :pointY point-y :distanceInKm distance-in-km}))

--- a/test/clojurewerkz/neocons/rest/test/spatial_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/spatial_test.clj
@@ -1,0 +1,27 @@
+(ns clojurewerkz.neocons.rest.test.spatial-test
+  (:require [clojurewerkz.neocons.rest               :as neorest]
+            [clojurewerkz.neocons.rest.nodes         :as nodes]
+            [clojurewerkz.neocons.rest.spatial       :as sp])
+  (:use clojure.test))
+
+(neorest/connect! "http://localhost:7474/db/data/")
+
+(deftest ^{:spatial true} test-create-layer
+  (let [created-layer-1 (sp/add-simple-point-layer "test-layer-1")
+        created-layer-2 (sp/add-simple-point-layer "test-layer-2" "x" "y")]
+    (is (= "test-layer-1" (:layer (:data created-layer-1))))
+    (is (= "test-layer-2" (:layer (:data created-layer-2))))
+    (is (= "y:x" (:geomencoder_config (:data created-layer-2))))))
+
+(deftest ^{:spatial true} test-add-node-to-layer
+  (let [created-layer-1 (sp/add-simple-point-layer "test-layer-add")
+        test-node (nodes/create {:latitude 60.1 :longitude 15.4 :foo "bar"})
+        added-node (sp/add-node-to-layer "test-layer-add" test-node)]
+    (is (= [15.4 60.1 15.4 60.1] (:bbox (:data added-node))))))
+
+(deftest ^{:spatial true} test-find-within-distance
+  (let [created-layer-1 (sp/add-simple-point-layer "test-layer-search")
+        test-node (nodes/create {:latitude -60.1 :longitude -15.4 :foo "target test node"})
+        added-node (sp/add-node-to-layer "test-layer-search" test-node)
+        found (sp/find-within-distance "test-layer-search" -15.0 -60.0 100)]
+    (is (= "target test node" (:foo (:data (first found)))))))


### PR DESCRIPTION
This pull request adds support for the three most common operations of the neo4j-spatial plugin:
- Create spatial layer
- Add node to spatial layer
- Find nodes within a certain distance of a point in a spatial layer

The tests for the spatial functions are disabled by default since travis doesn't seem to have the plugin installed.
