### PR TITLE
Added a with-transaction macro

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,7 +51,7 @@ committing or checking for exceptions, you can use the
 ``` clojure
 (require '[clojurewerkz.neocons.rest.transaction :as tx])
 
-(let [[transaction _] (tx/begin)]
+(let [transaction (tx/begin-tx)]
   (tx/with-transaction
     transaction
     true

--- a/src/clojure/clojurewerkz/neocons/rest/transaction.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/transaction.clj
@@ -56,6 +56,11 @@
       nil
       [neo-trans (make-cypher-responses payload)]))))
 
+(defn begin-tx
+  "Starts a transaction without any cypher statements."
+  []
+  (first (begin [])))
+
 (defn execute
   "Executes cypher statements in an existing transaction and returns the new transaction record along
   with the cypher results. If no cypher statement is give, the effect is to keep the transaction alive

--- a/test/clojurewerkz/neocons/rest/test/transaction_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/transaction_test.clj
@@ -110,15 +110,19 @@
     (is (= (:data (second result)) [{:row [{:name "My Another Node"}]}]))
     (is (= (:columns (second result)) ["n"] ))))
 
+(deftest ^{:edge-features true} test-empty-begin-tx
+  (let [transaction (tx/begin-tx)]
+    (are [x] (not (nil? (x transaction)))
+         :commit
+         :location
+         :expires)))
+
+
 (deftest ^{:edge-features true} test-with-transaction-commit-success
-  (let [[transaction _] (tx/begin)]
+  (let [transaction (tx/begin-tx)]
     (is (= (tx/with-transaction
              transaction
              true
-             (are [x] (not (nil? (x transaction)))
-                  :commit
-                  :location
-                  :expires)
              (let [[_ r] (tx/execute
                            transaction
                            [(tx/statement "CREATE (n {props}) RETURN n"
@@ -130,7 +134,7 @@
 
 
 (deftest ^{:edge-features true} test-with-transaction-rollback-success
-  (let [[transaction _] (tx/begin)]
+  (let [transaction (tx/begin-tx)]
     (tx/with-transaction
       transaction
       false
@@ -145,7 +149,7 @@
              [])))))
 
 (deftest ^{:edge-features true} test-with-transaction-manual-failure
-  (let [[transaction _] (tx/begin)]
+  (let [transaction (tx/begin-tx)]
     (is (thrown-with-msg?
           Exception #"Rolling back"
           (tx/with-transaction
@@ -156,7 +160,7 @@
             (throw (Exception. "Rolling back")))))))
 
 (deftest ^{:edge-features true} test-with-transaction-transaction-failure
-  (let [[transaction _] (tx/begin)]
+  (let [transaction (tx/begin-tx)]
     (is (thrown-with-msg?
           Exception #"STATEMENT_SYNTAX_ERROR"
           (tx/with-transaction


### PR DESCRIPTION
I've added a macro which gives the user a much more fine grained control over what to do with the transaction in the body of the macro.

This lets a user execute some statements, manipulate the results, and then do execute more statements based on the results.

You have to specify if you want commit on success behaviour (first argument to the macro). This gives you the flexibility that you can test some statements and you can manually roll them back if you want.

I chose to have the user specify the name of the transaction variable (second argument to the macro). I could have used an anaphoric macro, ie, fixed that variable name by convention to, say `transaction`, but I thought that would be unclean.

Comments welcome.

cheers
