### PR TITLE
Renamed the drop constraint to drop-unique for future portability.

### DIFF
--- a/src/clojure/clojurewerkz/neocons/rest/constraints.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/constraints.clj
@@ -3,8 +3,7 @@
   (:require [clojurewerkz.neocons.rest              :as rest]
             [cheshire.core                          :as json]
             [clojurewerkz.neocons.rest.conversion   :as conv]
-            [clojurewerkz.support.http.statuses     :refer [missing?]])
-  (:refer-clojure :exclude [drop]))
+            [clojurewerkz.support.http.statuses     :refer [missing?]]))
 
 (defn- get-url
   [^String label]
@@ -54,7 +53,7 @@
   ([label]
      (get-uniquess-constraints label "")))
 
-(defn drop
+(defn drop-unique
   "Drops an existing uniquenss constraint on an label and property.
   See http://docs.neo4j.org/chunked/milestone/rest-api-schema-constraints.html#rest-api-drop-constraint"
 

--- a/test/clojurewerkz/neocons/rest/test/constraints_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/constraints_test.clj
@@ -20,7 +20,7 @@
       (is (contains? (set (cts/get-unique dummy-label)) dummy-constraint))
       (is (contains? (set (cts/get-all dummy-label)) dummy-constraint))
       (is (contains? (set (cts/get-all)) dummy-constraint))
-      (cts/drop dummy-label :name)
+      (cts/drop-unique dummy-label :name)
       (is (not (contains?
                  (set (cts/get-unique dummy-label))
                  dummy-constraint))))))


### PR DESCRIPTION
I've additionally run the tests against neo4j 2.0.0M6.
