### PR TITLE
Bugfix: Connect now correctly handles login/password as part of url.

### DIFF
--- a/src/clojure/clojurewerkz/neocons/rest.clj
+++ b/src/clojure/clojurewerkz/neocons/rest.clj
@@ -80,8 +80,9 @@
 (defn connect
   "Connects to given Neo4J REST API endpoint and performs service discovery"
   ([^String uri]
-     (let [login    (env-var "NEO4J_LOGIN")
-           password (env-var "NEO4J_PASSWORD")]
+     (let [[login password] (http/parse-user-info (:user-info (http/parse-url uri)))
+           login    (or login    (env-var "NEO4J_LOGIN"))
+           password (or password (env-var "NEO4J_PASSWORD"))]
        (connect uri login password)))
   ([^String uri login password]
      (let [basic-auth              (if (and login password)
@@ -92,7 +93,7 @@
                                         uri)]
        (if (success? status)
          (let [payload    (json/decode body true)
-               http-auth  (:basic-auth basic-auth)
+               http-auth  basic-auth
                endpoint   (Neo4JEndpoint. (:neo4j_version      payload)
                                           (:node               payload)
                                           (str uri (if (.endsWith uri "/")


### PR DESCRIPTION
Using neocons to run against GrapheneDB failed: Connect with userinfo as part of url worked correctly, but the connection object that was returned didn't contain the necessary http-auth object, so further use of that connection object would fail with status code 401. That bug is fixed, and the unit tests are now improved.

However the tests still have a weakness since using Apache as a proxy will return a connection object containing urls pointing directly to Neo4j thus bypassing the proxy (and the authentication).
