### PR TITLE
Return results in graph format fixes #59

### DIFF
--- a/test/clojurewerkz/neocons/rest/test/transaction_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/transaction_test.clj
@@ -20,6 +20,13 @@
          (tx/statement "CREATE (n {props}) RETURN n" {:props {:name "My Node"}})
          {:statement "CREATE (n {props}) RETURN n"
           :parameters {:props {:name "My Node"}}}))
+  
+  (deftest test-converting-from-tx-statement-from-with-result-data-contents
+    (are [x y] (= y (tx/tx-statement-from x))
+         (tx/statement "CREATE (n {props}) RETURN n" {:props {:name "My Node"}} [:graph])
+         {:statement "CREATE (n {props}) RETURN n"
+          :parameters {:props {:name "My Node"}}
+          :resultDataContents [:graph]}))
 
   (deftest test-converting-from-tx-payload-from
     (are [x y] (= y (tx/tx-payload-from x))


### PR DESCRIPTION
This adds an extra result-data-contents parameter to transaction/statement which when you pass [:graph] would cause Neo4J to return the results in graph format.

There is only one additional test. I didn't think any more were necessary, but happy to try to get more in if you like.
