### PR TITLE
Neo4j 2.2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/*
 deploy.docs.sh
 .lein-*
 target/*
+.nrepl-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: clojure
 lein: lein2
 before_install:
 - "./bin/ci/start_neo4j_server.sh"
-script: lein2 test :travis
+script: "./bin/ci/test.sh"
 jdk:
 - openjdk7
 - oraclejdk7

--- a/bin/ci/start_neo4j_server.sh
+++ b/bin/ci/start_neo4j_server.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-VERSION="2.0.1"
-TARBALL="neo4j2.0.tar.gz"
+VERSION="2.2.0-RC01"
+TARBALL="neo4j2.2.tar.gz"
 
 cd /tmp
 wget -O $TARBALL "http://dist.neo4j.org/neo4j-community-$VERSION-unix.tar.gz?edition=community&version=$VERSION&distribution=tarball&dlid=2803678"

--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+lein run -m clojurewerkz.neocons.rest.password http://localhost:7474/ neo4j neo4j qwerty
+
+NEO4J_LOGIN=neo4j NEO4J_PASSWORD=qwerty lein test :travis

--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-lein run -m clojurewerkz.neocons.rest.password http://localhost:7474/ neo4j neo4j qwerty
+lein run -m clojurewerkz.neocons.rest.passwords http://localhost:7474/ neo4j neo4j qwerty
 
 NEO4J_LOGIN=neo4j NEO4J_PASSWORD=qwerty lein test :travis

--- a/src/clojure/clojurewerkz/neocons/rest/password.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/password.clj
@@ -1,0 +1,25 @@
+(ns clojurewerkz.neocons.rest.password
+  (:require [cheshire.core             :as json]
+            [clojurewerkz.neocons.rest :as nr]
+            [clojurewerkz.support.http.statuses :refer [success?]])
+  (:gen-class))
+
+
+(defn change-password
+  [uri username old-password new-password]
+  (let [{:keys [status body]}  (nr/POST (nr/map->Connection {:options {} :http-auth {:basic-auth [username old-password]}})
+                                        (str uri "user/" username "/password")
+                                        :body (json/encode {:password new-password}))]
+
+    (when (success? status)
+      (println "Password changed!"))))
+
+
+(defn -main
+  [& args]
+  (let  [[uri user password new-password]  args]
+    (when new-password
+      (change-password uri
+                       user
+                       password
+                       new-password))))

--- a/src/clojure/clojurewerkz/neocons/rest/passwords.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/passwords.clj
@@ -1,4 +1,4 @@
-(ns clojurewerkz.neocons.rest.password
+(ns clojurewerkz.neocons.rest.passwords
   (:require [cheshire.core             :as json]
             [clojurewerkz.neocons.rest :as nr]
             [clojurewerkz.support.http.statuses :refer [success?]])

--- a/test/clojurewerkz/neocons/rest/test/cypher_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/cypher_test.clj
@@ -41,9 +41,12 @@
       (is (= 2 (count data)))
       (is (= ["john" "fof"] columns))
       (is (same-node? john (first row1)))
-      (is (same-node? maria (last row1)))
+      (is (or (same-node? maria (last row1))
+              (same-node? steve (last row1))))
       (is (same-node? john (first row2)))
-      (is (same-node? steve (last row2)))))
+      (is (or (same-node? maria (last row2))
+              (same-node? steve (last row2))))
+      (is (not (same-node? (last row2) (last row1))))))
 
   (deftest ^{:cypher true} test-cypher-query-example2
     (let [john  (nodes/create conn {:name "John"})

--- a/test/clojurewerkz/neocons/rest/test/traversal_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/traversal_test.clj
@@ -26,10 +26,10 @@
           _    (relationships/create conn john pete :friend)
           _    (relationships/create conn adam pete :friend)
           xs1  (nodes/traverse conn (:id john) :relationships [{:direction "all" :type "friend"}])
-          ids1 (vec (map :id xs1))
+          ids1 (set (map :id xs1))
           xs2  (nodes/traverse conn (:id john) :relationships [{:direction "all" :type "enemy"}])
           ids2 (map :id xs2)]
-      (is (= [(:id john) (:id adam) (:id pete)] ids1))
+      (is (= #{(:id john) (:id adam) (:id pete)} ids1))
       (is (= [(:id john)] ids2))))
 
 
@@ -41,10 +41,10 @@
           rel2 (relationships/create conn john pete :friend)
           rel3 (relationships/create conn adam pete :friend)
           xs1  (relationships/traverse conn (:id john) :relationships [{:direction "all" :type "friend"}])
-          ids1 (vec (map :id xs1))
+          ids1 (set (map :id xs1))
           xs2  (relationships/traverse conn (:id john) :relationships [{:direction "all" :type "enemy"}])
           ids2 (map :id xs2)]
-      (is (= [(:id rel1) (:id rel2)] ids1))
+      (is (= #{(:id rel1) (:id rel2)} ids1))
       (is (empty? ids2))))
 
 
@@ -111,20 +111,20 @@
   ;;
 
   (deftest ^{:traversal true} test-shortest-path-algorithm-1
-    (let [john (nodes/create conn {:name "John"      :age 28 :location "New York City, NY"})
-          liz  (nodes/create conn {:name "Liz"       :age 27 :location "Buffalo, NY"})
-          beth (nodes/create conn {:name "Elizabeth" :age 30 :location "Chicago, IL"})
-          bern (nodes/create conn {:name "Bernard"   :age 33 :location "Zürich"})
-          gael (nodes/create conn {:name "Gaël"      :age 31 :location "Montpellier"})
-          alex (nodes/create conn {:name "Alex"      :age 24 :location "Toronto, ON"})
-          rel1 (relationships/create conn john liz  :knows)
-          rel2 (relationships/create conn liz  beth :knows)
-          rel3 (relationships/create conn liz  bern :knows)
-          rel4 (relationships/create conn bern gael :knows)
-          rel5 (relationships/create conn gael beth :knows)
-          rel6 (relationships/create conn beth gael :knows)
-          rel7 (relationships/create conn john gael :knows)
-          rt   {:type "knows" :direction "out"}
+    (let [john  (nodes/create conn {:name "John"      :age 28 :location "New York City, NY"})
+          liz   (nodes/create conn {:name "Liz"       :age 27 :location "Buffalo, NY"})
+          beth  (nodes/create conn {:name "Elizabeth" :age 30 :location "Chicago, IL"})
+          bern  (nodes/create conn {:name "Bernard"   :age 33 :location "Zürich"})
+          gael  (nodes/create conn {:name "Gaël"      :age 31 :location "Montpellier"})
+          alex  (nodes/create conn {:name "Alex"      :age 24 :location "Toronto, ON"})
+          rel1  (relationships/create conn john liz  :knows)
+          rel2  (relationships/create conn liz  beth :knows)
+          rel3  (relationships/create conn liz  bern :knows)
+          rel4  (relationships/create conn bern gael :knows)
+          rel5  (relationships/create conn gael beth :knows)
+          rel6  (relationships/create conn beth gael :knows)
+          rel7  (relationships/create conn john gael :knows)
+          rt    {:type "knows" :direction "out"}
           xs1   (paths/all-shortest-between conn (:id john) (:id liz)  :relationships [rt] :max-depth 1)
           path1 (first xs1)
           xs2   (paths/all-shortest-between conn (:id john) (:id beth) :relationships [rt] :max-depth 1)
@@ -166,9 +166,12 @@
       (is (paths/node-in? conn john path7))
       (is (not (paths/node-in? conn bern path7)))
       (is (paths/included-in? conn john path7))
-      (is (paths/included-in? conn rel1 path7))
-      (is (paths/relationship-in? conn (:id rel1) path7))
-      (is (paths/relationship-in? conn rel1 path7))
+      (is (or (paths/included-in? conn rel1 path7)
+              (paths/included-in? conn rel7 path7)))
+      (is (or (paths/relationship-in? conn (:id rel1) path7)
+              (paths/relationship-in? conn (:id rel7) path7)))
+      (is (or (paths/relationship-in? conn rel1 path7)
+              (paths/relationship-in? conn rel7 path7)))
       (is (not (paths/included-in? conn rel4 path7)))
       (is (not (paths/relationship-in? conn (:id rel4) path7)))
       (is (not (paths/relationship-in? conn rel4 path7)))


### PR DESCRIPTION
Neo4j 2.2 adds an API for [Authentication & Authorization](http://neo4j.com/docs/2.2.0-RC01/rest-api-security.html). It used basic http-auth parameters for this which was already implemented by Neocons.

My changes:

- Fixed failing tests: Some of the test depended on the return order of some queries. 
- Added a method for resetting the default password: Neo4j Server by default has auth turned on and the user has to change the default password before doing anything. I've implemented a basic password changing function. NOTE: I've decided not to implement the whole auth API as most of the time people who use the library should already have a valid username and password.

