### PR TITLE
If no secure variables are set, don't run any graphene tests

### DIFF
--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -2,4 +2,8 @@
 
 lein run -m clojurewerkz.neocons.rest.passwords http://localhost:7474/ neo4j neo4j qwerty
 
-NEO4J_LOGIN=neo4j NEO4J_PASSWORD=qwerty lein test :travis
+if ["$TRAVIS_SECURE_ENV_VARS" = "true"]; then
+  NEO4J_LOGIN=neo4j NEO4J_PASSWORD=qwerty lein test :travis
+else
+  NEO4J_LOGIN=neo4j NEO4J_PASSWORD=qwerty lein test :default
+fi


### PR DESCRIPTION
I've modified the `test.sh` file so that the graphene tests don't run if the secure environment variables aren't set.

This will hopefully let us fix the failing build #70.

cc @ricardojmendez