### PR TITLE
adds update to list of exclusions

### DIFF
--- a/src/clojure/clojurewerkz/neocons/rest/relationships.clj
+++ b/src/clojure/clojurewerkz/neocons/rest/relationships.clj
@@ -9,7 +9,7 @@
 ;; You must not remove this notice, or any other, from this software.
 
 (ns clojurewerkz.neocons.rest.relationships
-  (:refer-clojure :exclude [get find])
+  (:refer-clojure :exclude [get find update])
   (:require [cheshire.core                     :as json]
             [clojurewerkz.neocons.rest         :as rest]
             [clojurewerkz.neocons.rest.cypher  :as cypher]


### PR DESCRIPTION
suppresses:  
`WARNING: update already refers to: #'clojure.core/update in namespace: clojurewerkz.neocons.rest.relationships, being replaced by: #'clojurewerkz.neocons.rest.relationships/update`
