### PR TITLE
Support HTTP options, fix tests & tip in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ all supported Clojure versions using
 Then create a branch and make your changes on it. Once you are done with your changes and all tests pass, submit
 a pull request on Github.
 
+The tests require a Neo4j on localhost on port 7474. An easy way to
+arrange for this if you do not generally run a local server may be to
+use docker:
+
+`docker run --publish=7474:7474 --publish=7687:7687 --volume=$HOME/neo4j/data:/data neo4j`
+
+and pass the default credentials to lein on the command line
+
+`NEO4J_LOGIN=neo4j NEO4J_PASSWORD=admin lein test`
 
 ## License
 

--- a/src/clojure/clojurewerkz/neocons/rest.clj
+++ b/src/clojure/clojurewerkz/neocons/rest.clj
@@ -91,11 +91,14 @@
            password (or password (env-var "NEO4J_PASSWORD"))]
        (connect uri login password)))
   ([^String uri login password]
+   (connect uri login password {}))
+  ([^String uri login password options]
      (let [basic-auth              (if (and login password)
                                      {:basic-auth [login password]}
                                      {})
+           options                   (merge-with merge options USER-AGENT)
            {:keys [status body]}   (GET (map->Connection
-                                         {:http-auth basic-auth :options USER-AGENT})
+                                         {:http-auth basic-auth :options options})
                                         uri)]
        (if (success? status)
          (let [payload    (json/decode body true)
@@ -117,5 +120,5 @@
                                           (:transaction        payload))]
            (map->Connection
             {:endpoint  endpoint
-             :options   USER-AGENT
+             :options   options
              :http-auth http-auth}))))))

--- a/test/clojurewerkz/neocons/rest/test/connection_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/connection_test.clj
@@ -26,3 +26,11 @@
     (is (:node-uri               endpoint))
     (is (:batch-uri              endpoint))
     (is (:relationship-types-uri endpoint))))
+
+(deftest test-passing-clj-http-options-to-connect
+  (let [connection (neorest/connect "http://localhost:7474/db/data"
+                                    (get (System/getenv) "NEO4J_LOGIN")
+                                    (get (System/getenv) "NEO4J_PASSWORD")
+                                    {:save-request? true})]
+    (is (:endpoint connection))
+    (is (get-in connection [:options :save-request?]))))

--- a/test/clojurewerkz/neocons/rest/test/labels_test.clj
+++ b/test/clojurewerkz/neocons/rest/test/labels_test.clj
@@ -24,7 +24,7 @@
   (deftest test-creating-multiple-label
     (let [n (nodes/create conn)]
       (labels/add conn n [:MyLabel :MyOtherLabel])
-      (is (= (labels/get-all-labels conn n) [:MyLabel :MyOtherLabel]))))
+      (is (= (set (labels/get-all-labels conn n)) #{:MyLabel :MyOtherLabel}))))
 
   (deftest test-creating-invalid-label
     (let [n (nodes/create conn)]
@@ -35,7 +35,7 @@
     (let [n (nodes/create conn)]
       (labels/add conn n :MyLabel)
       (labels/replace conn n [:MyOtherLabel :MyThirdLabel])
-      (is (= (labels/get-all-labels conn n) [:MyOtherLabel :MyThirdLabel]))))
+      (is (= (set (labels/get-all-labels conn n)) #{:MyOtherLabel :MyThirdLabel}))))
 
   (deftest test-deleting-label
     (let [n (nodes/create conn)]


### PR DESCRIPTION
Allows clj-http options to be passed in the initial connect rather than pasted on afterwards.

This is important, for instance, if you need to pass a custom trust-store to clj-http to configure the trust of a cert that isn't accepted by default. The initial GET (inside the connect call) will fail if there is no opportunity to specify this.

Also fixed a failing test and popped in a handy hint on running the tests which isn't really important.